### PR TITLE
Fix user for repository metadata

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -3,7 +3,7 @@ version = "0.3.0"
 licences = ["Apache-2.0"]
 description = "Work with JSON in Gleam"
 
-repository = { type = "github", user = "gleam", repo = "json" }
+repository = { type = "github", user = "gleam-lang", repo = "json" }
 links = [
   { title = "Website", href = "https://gleam.run" },
   { title = "Sponsor", href = "https://github.com/sponsors/lpil" },


### PR DESCRIPTION
I noticed that the "Repository" link on Hex.pm pointed to `https://github.com/gleam/json` instead of `https://github.com/gleam-lang/json`