### PR TITLE
Add javascript support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,4 +17,5 @@ jobs:
           elixir-version: "1.13.1"
           gleam-version: "0.20.0"
       - run: gleam test
+      - run: gleam test --target javascript
       - run: gleam format --check src test

--- a/gleam.toml
+++ b/gleam.toml
@@ -14,4 +14,4 @@ gleam_stdlib = "~> 0.19"
 thoas = "~> 0.2"
 
 [dev-dependencies]
-gleeunit = "~> 0.5"
+gleeunit = "~> 0.6"

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,11 +3,11 @@
 
 packages = [
   { name = "gleam_stdlib", version = "0.19.2", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "FFA79EA12369F122B68885E694E097D6810402A2F86BFF48AAE9E40ACE654F4C" },
-  { name = "gleeunit", version = "0.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "77701A5E5A565727E1EEAC9196FB878D544049B6331CD0305B5A69699135EA1C" },
+  { name = "gleeunit", version = "0.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "5BF486C3E135B7F5ED8C054925FC48E5B2C79016A39F416FD8CF2E860520EE55" },
   { name = "thoas", version = "0.2.0", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "630AAEE57FB3FDE201578E787259E15E788A27733D49DE8DCCE1354DB1885B8D" },
 ]
 
 [requirements]
 gleam_stdlib = "~> 0.19"
-gleeunit = "~> 0.5"
+gleeunit = "~> 0.6"
 thoas = "~> 0.2"

--- a/src/gleam/json.gleam
+++ b/src/gleam/json.gleam
@@ -62,7 +62,7 @@ if javascript {
   }
 
   external fn decode_string(String) -> Result(Dynamic, DecodeError) =
-    "../gleam_json_ffi.mjs" "decode_string"
+    "../gleam_json_ffi.mjs" "decode"
 }
 
 /// Decode a JSON bit string into dynamically typed data which can be decoded
@@ -94,18 +94,18 @@ pub fn decode_bits(
   |> result.map_error(UnexpectedFormat)
 }
 
-fn decode_to_dynamic(bit_string: BitString) -> Result(Dynamic, DecodeError) {
-  do_decode_to_dynamic(bit_string)
-}
-
 if erlang {
-  external fn do_decode_to_dynamic(BitString) -> Result(Dynamic, DecodeError) =
+  external fn decode_to_dynamic(BitString) -> Result(Dynamic, DecodeError) =
     "gleam_json_ffi" "decode"
 }
 
 if javascript {
-  external fn do_decode_to_dynamic(BitString) -> Result(Dynamic, DecodeError) =
-    "../gleam_json_ffi.mjs" "decode"
+  fn decode_to_dynamic(json: BitString) -> Result(Dynamic, DecodeError) {
+    case bit_string.to_string(json) {
+      Ok(string) -> decode_string(string)
+      Error(Nil) -> Error(UnexpectedByte("", 0))
+    }
+  }
 }
 
 /// Convert a JSON value into a string.

--- a/src/gleam/json.gleam
+++ b/src/gleam/json.gleam
@@ -38,8 +38,31 @@ pub fn decode(
   from json: String,
   using decoder: dynamic.Decoder(t),
 ) -> Result(t, DecodeError) {
-  let bits = bit_string.from_string(json)
-  decode_bits(bits, decoder)
+  do_decode(from: json, using: decoder)
+}
+
+if erlang {
+  fn do_decode(
+    from json: String,
+    using decoder: dynamic.Decoder(t),
+  ) -> Result(t, DecodeError) {
+    let bits = bit_string.from_string(json)
+    decode_bits(bits, decoder)
+  }
+}
+
+if javascript {
+  fn do_decode(
+    from json: String,
+    using decoder: dynamic.Decoder(t),
+  ) -> Result(t, DecodeError) {
+    try dynamic_value = decode_string(json)
+    decoder(dynamic_value)
+    |> result.map_error(UnexpectedFormat)
+  }
+
+  external fn decode_string(String) -> Result(Dynamic, DecodeError) =
+    "../gleam_json_ffi.mjs" "decode_string"
 }
 
 /// Decode a JSON bit string into dynamically typed data which can be decoded
@@ -158,7 +181,7 @@ if erlang {
 
 if javascript {
   external fn do_string(String) -> Json =
-    "../gleam_json_ffi.mjs" "string"
+    "../gleam_json_ffi.mjs" "identity"
 }
 
 /// Encode a bool into JSON.
@@ -181,7 +204,7 @@ if erlang {
 
 if javascript {
   external fn do_bool(Bool) -> Json =
-    "../gleam_json_ffi.mjs" "bool"
+    "../gleam_json_ffi.mjs" "identity"
 }
 
 /// Encode an int into JSON.
@@ -204,7 +227,7 @@ if erlang {
 
 if javascript {
   external fn do_int(Int) -> Json =
-    "../gleam_json_ffi.mjs" "int"
+    "../gleam_json_ffi.mjs" "identity"
 }
 
 /// Encode an float into JSON.
@@ -227,7 +250,7 @@ if erlang {
 
 if javascript {
   external fn do_float(input: Float) -> Json =
-    "../gleam_json_ffi.mjs" "float"
+    "../gleam_json_ffi.mjs" "identity"
 }
 
 /// The JSON value null.
@@ -297,7 +320,7 @@ if erlang {
 
 if javascript {
   external fn do_object(entries: List(#(String, Json))) -> Json =
-    "../gleam_json_ffi.mjs" "object_from"
+    "../gleam_json_ffi.mjs" "object"
 }
 
 /// Encode a list into a JSON array.

--- a/src/gleam/json.gleam
+++ b/src/gleam/json.gleam
@@ -1,4 +1,3 @@
-import gleam/map
 import gleam/list
 import gleam/result
 import gleam/bit_string
@@ -72,8 +71,19 @@ pub fn decode_bits(
   |> result.map_error(UnexpectedFormat)
 }
 
-external fn decode_to_dynamic(BitString) -> Result(Dynamic, DecodeError) =
-  "gleam_json_ffi" "decode"
+fn decode_to_dynamic(bit_string: BitString) -> Result(Dynamic, DecodeError) {
+  do_decode_to_dynamic(bit_string)
+}
+
+if erlang {
+  external fn do_decode_to_dynamic(BitString) -> Result(Dynamic, DecodeError) =
+    "gleam_json_ffi" "decode"
+}
+
+if javascript {
+  external fn do_decode_to_dynamic(BitString) -> Result(Dynamic, DecodeError) =
+    "../gleam_json_ffi.mjs" "decode"
+}
 
 /// Convert a JSON value into a string.
 ///
@@ -87,8 +97,19 @@ external fn decode_to_dynamic(BitString) -> Result(Dynamic, DecodeError) =
 /// "[1,2,3]"
 /// ```
 ///
-pub external fn to_string(Json) -> String =
-  "gleam_json_ffi" "json_to_string"
+pub fn to_string(json: Json) -> String {
+  do_to_string(json)
+}
+
+if erlang {
+  external fn do_to_string(Json) -> String =
+    "gleam_json_ffi" "json_to_string"
+}
+
+if javascript {
+  external fn do_to_string(Json) -> String =
+    "../gleam_json_ffi.mjs" "json_to_string"
+}
 
 /// Convert a JSON value into a string builder.
 ///
@@ -103,8 +124,19 @@ pub external fn to_string(Json) -> String =
 /// string_builder.from_string("[1,2,3]")
 /// ```
 ///
-pub external fn to_string_builder(Json) -> StringBuilder =
-  "gleam_json_ffi" "json_to_iodata"
+pub fn to_string_builder(json: Json) -> StringBuilder {
+  do_to_string_builder(json)
+}
+
+if erlang {
+  external fn do_to_string_builder(Json) -> StringBuilder =
+    "gleam_json_ffi" "json_to_iodata"
+}
+
+if javascript {
+  external fn do_to_string_builder(Json) -> StringBuilder =
+    "../gleam_json_ffi.mjs" "json_to_string"
+}
 
 /// Encode a string into JSON, using normal JSON escaping.
 ///
@@ -115,8 +147,19 @@ pub external fn to_string_builder(Json) -> StringBuilder =
 /// "\"Hello!\""
 /// ```
 ///
-pub external fn string(input: String) -> Json =
-  "gleam_json_ffi" "string"
+pub fn string(input: String) -> Json {
+  do_string(input)
+}
+
+if erlang {
+  external fn do_string(String) -> Json =
+    "gleam_json_ffi" "string"
+}
+
+if javascript {
+  external fn do_string(String) -> Json =
+    "../gleam_json_ffi.mjs" "identity"
+}
 
 /// Encode a bool into JSON.
 ///
@@ -127,8 +170,19 @@ pub external fn string(input: String) -> Json =
 /// "false"
 /// ```
 ///
-pub external fn bool(input: Bool) -> Json =
-  "gleam_json_ffi" "bool"
+pub fn bool(input: Bool) -> Json {
+  do_bool(input)
+}
+
+if erlang {
+  external fn do_bool(Bool) -> Json =
+    "gleam_json_ffi" "bool"
+}
+
+if javascript {
+  external fn do_bool(Bool) -> Json =
+    "../gleam_json_ffi.mjs" "identity"
+}
 
 /// Encode an int into JSON.
 ///
@@ -139,8 +193,19 @@ pub external fn bool(input: Bool) -> Json =
 /// "50"
 /// ```
 ///
-pub external fn int(input: Int) -> Json =
-  "gleam_json_ffi" "int"
+pub fn int(input: Int) -> Json {
+  do_int(input)
+}
+
+if erlang {
+  external fn do_int(Int) -> Json =
+    "gleam_json_ffi" "int"
+}
+
+if javascript {
+  external fn do_int(Int) -> Json =
+    "../gleam_json_ffi.mjs" "identity"
+}
 
 /// Encode an float into JSON.
 ///
@@ -151,8 +216,19 @@ pub external fn int(input: Int) -> Json =
 /// "4.7"
 /// ```
 ///
-pub external fn float(input: Float) -> Json =
-  "gleam_json_ffi" "float"
+pub fn float(input: Float) -> Json {
+  do_float(input)
+}
+
+if erlang {
+  external fn do_float(input: Float) -> Json =
+    "gleam_json_ffi" "float"
+}
+
+if javascript {
+  external fn do_float(input: Float) -> Json =
+    "../gleam_json_ffi.mjs" "identity"
+}
 
 /// The JSON value null.
 ///
@@ -163,8 +239,19 @@ pub external fn float(input: Float) -> Json =
 /// "null"
 /// ```
 ///
-pub external fn null() -> Json =
-  "gleam_json_ffi" "null"
+pub fn null() -> Json {
+  do_null()
+}
+
+if erlang {
+  external fn do_null() -> Json =
+    "gleam_json_ffi" "null"
+}
+
+if javascript {
+  external fn do_null() -> Json =
+    "../gleam_json_ffi.mjs" "do_null"
+}
 
 /// Encode an optional value into JSON, using null if it the `None` variant.
 ///
@@ -199,8 +286,19 @@ pub fn nullable(from input: Option(a), of inner_type: fn(a) -> Json) -> Json {
 /// "{\"game\":\"Pac-Mac\",\"score\":3333360}"
 /// ```
 ///
-pub external fn object(entries: List(#(String, Json))) -> Json =
-  "gleam_json_ffi" "object"
+pub fn object(entries: List(#(String, Json))) -> Json {
+  do_object(entries)
+}
+
+if erlang {
+  external fn do_object(entries: List(#(String, Json))) -> Json =
+    "gleam_json_ffi" "object"
+}
+
+if javascript {
+  external fn do_object(entries: List(#(String, Json))) -> Json =
+    "../gleam_json_ffi.mjs" "object_from"
+}
 
 /// Encode a list into a JSON array.
 ///
@@ -226,5 +324,16 @@ pub fn array(from entries: List(a), of inner_type: fn(a) -> Json) -> Json {
 /// "[1, 2.0, \"3\"]"
 /// ```
 ///
-pub external fn preprocessed_array(from: List(Json)) -> Json =
-  "gleam_json_ffi" "array"
+pub fn preprocessed_array(from: List(Json)) -> Json {
+  do_preprocessed_array(from)
+}
+
+if erlang {
+  external fn do_preprocessed_array(from: List(Json)) -> Json =
+    "gleam_json_ffi" "array"
+}
+
+if javascript {
+  external fn do_preprocessed_array(from: List(Json)) -> Json =
+    "../gleam_json_ffi.mjs" "array"
+}

--- a/src/gleam/json.gleam
+++ b/src/gleam/json.gleam
@@ -158,7 +158,7 @@ if erlang {
 
 if javascript {
   external fn do_string(String) -> Json =
-    "../gleam_json_ffi.mjs" "identity"
+    "../gleam_json_ffi.mjs" "string"
 }
 
 /// Encode a bool into JSON.
@@ -181,7 +181,7 @@ if erlang {
 
 if javascript {
   external fn do_bool(Bool) -> Json =
-    "../gleam_json_ffi.mjs" "identity"
+    "../gleam_json_ffi.mjs" "bool"
 }
 
 /// Encode an int into JSON.
@@ -204,7 +204,7 @@ if erlang {
 
 if javascript {
   external fn do_int(Int) -> Json =
-    "../gleam_json_ffi.mjs" "identity"
+    "../gleam_json_ffi.mjs" "int"
 }
 
 /// Encode an float into JSON.
@@ -227,7 +227,7 @@ if erlang {
 
 if javascript {
   external fn do_float(input: Float) -> Json =
-    "../gleam_json_ffi.mjs" "identity"
+    "../gleam_json_ffi.mjs" "float"
 }
 
 /// The JSON value null.

--- a/src/gleam_json_ffi.mjs
+++ b/src/gleam_json_ffi.mjs
@@ -36,7 +36,7 @@ export function decode(string) {
   }
 }
 
-function getJsonDecodeError(stdErr, json) {
+export function getJsonDecodeError(stdErr, json) {
   if (isUnexpectedEndOfInput(stdErr)) return new UnexpectedEndOfInput()
   const unexpectedByteRuntime = getUnexpectedByteRuntime(stdErr)
   if (unexpectedByteRuntime) return toUnexpectedByteError(unexpectedByteRuntime, stdErr, json)
@@ -88,7 +88,7 @@ const chromiumUnexpectedByteRegex = /unexpected token (.) in JSON at position (\
  * 
  * JavascriptCore only reports what the character is and not its position.
  */
-const jsCoreUnexpectedByteRegex = /unexpected identifier "(.)"/i
+const jsCoreUnexpectedByteRegex = /unexpected (identifier|token) "(.)"/i
 
 /**
  * Matches unexpected byte messages in:
@@ -96,7 +96,7 @@ const jsCoreUnexpectedByteRegex = /unexpected identifier "(.)"/i
  * 
  * Matches the position in a 2d grid only and not the character.
  */
-const spidermonkeyUnexpectedByteRegex = /(unexpected character|expected double-quoted property name) at line (\d+) column (\d+)/i
+const spidermonkeyUnexpectedByteRegex = /(unexpected character|expected .*) at line (\d+) column (\d+)/i
 
 function getUnexpectedByteRuntime(err) {
   if (chromiumUnexpectedByteRegex.test(err.message)) return Runtime.chromium
@@ -151,7 +151,7 @@ function toSpidermonkeyUnexpectedByteError(err, json) {
 
 function toJsCoreUnexpectedByteError(err) {
   const match = jsCoreUnexpectedByteRegex.exec(err.message)
-  const byte = toHex(match[1])
+  const byte = toHex(match[2])
   return new UnexpectedByte(byte, 0)
 }
 

--- a/src/gleam_json_ffi.mjs
+++ b/src/gleam_json_ffi.mjs
@@ -80,7 +80,7 @@ function isUnexpectedEndOfInput(err) {
  * 
  * Matches the character and its position.
  */
-const chromiumUnexpectedByteRegex = /unexpected token (.) in JSON at position (\d+)/
+const chromiumUnexpectedByteRegex = /unexpected token (.) in JSON at position (\d+)/i
 
 /**
  * Matches unexpected byte messages in:
@@ -96,7 +96,7 @@ const jsCoreUnexpectedByteRegex = /unexpected identifier "(.)"/i
  * 
  * Matches the position in a 2d grid only and not the character.
  */
-const spidermonkeyUnexpectedByteRegex = /((unexpected character|expected double-quoted property name) at line (\d+) column (\d+))/i
+const spidermonkeyUnexpectedByteRegex = /(unexpected character|expected double-quoted property name) at line (\d+) column (\d+)/i
 
 function getUnexpectedByteRuntime(err) {
   if (chromiumUnexpectedByteRegex.test(err.message)) return Runtime.chromium
@@ -142,8 +142,8 @@ function toChromiumUnexpectedByteError(err) {
 
 function toSpidermonkeyUnexpectedByteError(err, json) {
   const match = spidermonkeyUnexpectedByteRegex.exec(err.message)
-  const line = Number(match[1])
-  const column = Number(match[2])
+  const line = Number(match[2])
+  const column = Number(match[3])
   const position = getPositionFromMultiline(line, column, json)
   const byte = toHex(err.message[position])
   return new UnexpectedByte(byte, position)

--- a/src/gleam_json_ffi.mjs
+++ b/src/gleam_json_ffi.mjs
@@ -145,7 +145,7 @@ function toSpidermonkeyUnexpectedByteError(err, json) {
   const line = Number(match[2])
   const column = Number(match[3])
   const position = getPositionFromMultiline(line, column, json)
-  const byte = toHex(err.message[position])
+  const byte = toHex(json[position])
   return new UnexpectedByte(byte, position)
 }
 

--- a/src/gleam_json_ffi.mjs
+++ b/src/gleam_json_ffi.mjs
@@ -1,0 +1,105 @@
+import { Ok, Error, CustomType } from './gleam.mjs'
+import { bit_string_to_string } from '../../gleam_stdlib/dist/gleam_stdlib.mjs'
+
+export class DecodeError extends CustomType {
+  get __gleam_prelude_variant__() {
+    return "DecodeError";
+  }
+}
+
+export class UnexpectedEndOfInput extends CustomType {
+  static isInstance(err) {
+    return err.message === 'Unexpected end of JSON input'
+  }
+
+  get __gleam_prelude_variant__() {
+    return "UnexpectedEndOfInput"
+  }
+}
+
+export class UnexpectedByte extends CustomType {
+  static regex = /Unexpected token (.) in JSON at position (\d+)/
+
+  static isInstance(err) {
+    return this.regex.test(err)
+  }
+
+  constructor(err) {
+    super()
+    const match = UnexpectedByte.regex.exec(err.message)
+    this.byte = "0x" + match[1].charCodeAt(0).toString(16).toUpperCase()
+    this.position = Number(match[2])
+  }
+
+  get __gleam_prelude_variant__() {
+    return `UnexpectedByte`;
+  }
+}
+
+export class UnexpectedSequence extends CustomType {
+  static isInstance(err) {
+    return false
+  }
+
+  get __gleam_prelude_variant__() {
+    return "UnexpectedSequence";
+  }
+}
+
+export class UnexpectedFormat extends CustomType {
+  static isInstance(err) {
+    return false
+  }
+
+  constructor(decodeErrs) {
+    super()
+    this[0] = decodeErrs
+  }
+
+  get __gleam_prelude_variant__() {
+    return "UnexpectedFormat";
+  }
+}
+
+export function json_to_string(json) {
+  return JSON.stringify(json)
+}
+
+export function object_from(entries) {
+  return Object.fromEntries(entries)
+}
+
+export function array(list) {
+  return list.toArray()
+}
+
+export function do_null() {
+  return null
+}
+
+export function identity(x) {
+  return x
+}
+
+export function decode(bit_string) {
+  const stringResult = bit_string_to_string(bit_string)
+  if (!stringResult.isOk()) return stringResult
+  try {
+    const result = JSON.parse(stringResult[0])
+    return new Ok(result)
+  } catch (err) {
+    return getJsonDecodeError(err)
+  }
+}
+
+function getJsonDecodeError(stdErr) {
+  const ErrClass = [
+    UnexpectedByte,
+    UnexpectedEndOfInput,
+    UnexpectedFormat,
+    UnexpectedSequence,
+  ].find((klass) => klass.isInstance(stdErr))
+
+  if (ErrClass) return new Error(new ErrClass(stdErr))
+  else return new Error()
+}

--- a/src/gleam_json_ffi.mjs
+++ b/src/gleam_json_ffi.mjs
@@ -1,6 +1,12 @@
 import { Ok, Error } from './gleam.mjs'
 import { UnexpectedByte, UnexpectedEndOfInput } from './gleam/json.mjs'
 
+const Runtime = {
+  chromium: 'chromium',
+  spidermonkey: 'spidermonkey',
+  jscore: 'jscore',
+}
+
 export function json_to_string(json) {
   return JSON.stringify(json)
 }
@@ -26,29 +32,141 @@ export function decode(string) {
     const result = JSON.parse(string)
     return new Ok(result)
   } catch (err) {
-    return new Error(getJsonDecodeError(err))
+    return new Error(getJsonDecodeError(err, string))
   }
 }
 
-function getJsonDecodeError(stdErr) {
-  if (isUnexpectedByte(stdErr)) return new toUnexpectedByteError(stdErr)
+function getJsonDecodeError(stdErr, json) {
   if (isUnexpectedEndOfInput(stdErr)) return new UnexpectedEndOfInput()
+  const unexpectedByteRuntime = getUnexpectedByteRuntime(stdErr)
+  if (unexpectedByteRuntime) return toUnexpectedByteError(unexpectedByteRuntime, stdErr, json)
   return new UnexpectedByte('', 0)
 }
 
+/**
+ * Matches unexpected end of input messages in:
+ * - Chromium (edge, chrome, node)
+ * - Spidermonkey (firefox)
+ * - JavascriptCore (safari)
+ * 
+ * Note that Spidermonkey and JavascriptCore will both incorrectly report some
+ * UnexpectedByte errors as UnexpectedEndOfInput errors. For example:
+ * 
+ * @example
+ * // in JavascriptCore
+ * JSON.parse('{"a"]: "b"})
+ * // => JSON Parse error: Expected ':' before value
+ * 
+ * JSON.parse('{"a"')
+ * // => JSON Parse error: Expected ':' before value
+ * 
+ * // in Chromium (correct)
+ * JSON.parse('{"a"]: "b"})
+ * // => Unexpected token ] in JSON at position 4
+ * 
+ * JSON.parse('{"a"')
+ * // => Unexpected end of JSON input
+ * 
+ * // in Chromium (correct)
+ * 
+ */
+const unexpectedEndOfInputRegex = /((unexpected (end|eof))|(end of data)|(unterminated string)|(json( parse error|\.parse)\: expected '(\:|\}|\])'))/i
+
 function isUnexpectedEndOfInput(err) {
-  return err.message.includes('Unexpected end') || err.message.includes('Unexpected EOF')
+  return unexpectedEndOfInputRegex.test(err.message)
 }
 
-const unexpectedByteRegex = /Unexpected token (.) in JSON at position (\d+)/
 
-function isUnexpectedByte(err) {
-  return unexpectedByteRegex.test(err)
+/**
+ * Matches unexpected byte messages in:
+ * - Chromium (edge, chrome, node)
+ * 
+ * Matches the character and its position.
+ */
+const chromiumUnexpectedByteRegex = /unexpected token (.) in JSON at position (\d+)/
+
+/**
+ * Matches unexpected byte messages in:
+ * - JavascriptCore (safari)
+ * 
+ * JavascriptCore only reports what the character is and not its position.
+ */
+const jsCoreUnexpectedByteRegex = /unexpected identifier "(.)"/i
+
+/**
+ * Matches unexpected byte messages in:
+ * - Spidermonkey (firefox)
+ * 
+ * Matches the position in a 2d grid only and not the character.
+ */
+const spidermonkeyUnexpectedByteRegex = /((unexpected character|expected double-quoted property name) at line (\d+) column (\d+))/i
+
+function getUnexpectedByteRuntime(err) {
+  if (chromiumUnexpectedByteRegex.test(err.message)) return Runtime.chromium
+  if (jsCoreUnexpectedByteRegex.test(err.message)) return Runtime.jscore
+  if (spidermonkeyUnexpectedByteRegex.test(err.message)) return Runtime.spidermonkey
+  return null
 }
 
-function toUnexpectedByteError(err) {
-  const match = unexpectedByteRegex.exec(err.message)
-  const byte = "0x" + match[1].charCodeAt(0).toString(16).toUpperCase()
+function toUnexpectedByteError(runtime, err, json) {
+  switch (runtime) {
+    case Runtime.chromium:
+      return toChromiumUnexpectedByteError(err)
+    case Runtime.spidermonkey:
+      return toSpidermonkeyUnexpectedByteError(err, json)
+    case Runtime.jscore:
+      return toJsCoreUnexpectedByteError(err)
+  }
+}
+
+function toChromiumUnexpectedByteError(err) {
+  const match = chromiumUnexpectedByteRegex.exec(err.message)
+  const byte = toHex(match[1])
   const position = Number(match[2])
   return new UnexpectedByte(byte, position)
+}
+
+function toSpidermonkeyUnexpectedByteError(err, json) {
+  const match = spidermonkeyUnexpectedByteRegex.exec(err.message)
+  const line = Number(match[1])
+  const column = Number(match[2])
+  const position = getPositionFromMultiline(line, column, json)
+  const byte = toHex(err.message[position])
+  return new UnexpectedByte(byte, position)
+}
+
+function toJsCoreUnexpectedByteError(err) {
+  const match = jsCoreUnexpectedByteRegex.exec(err.message)
+  const byte = toHex(match[1])
+  return new UnexpectedByte(byte, 0)
+}
+
+function toHex(char) {
+  return "0x" + char.charCodeAt(0).toString(16).toUpperCase()
+}
+
+/**
+ * Gets the position of a character in a flattened (i.e. single line) string
+ * from a line and column number. Note that the position is 0-indexed and 
+ * the line and column numbers are 1-indexed.
+ * 
+ * @param {number} line 
+ * @param {number} column 
+ * @param {string} string 
+ */
+function getPositionFromMultiline(line, column, string) {
+  if (line === 1) return column - 1
+
+  let currentLn = 1
+  let position = 0
+  string.split('').find((char, idx) => {
+    if (char === '\n') currentLn += 1
+    if (currentLn === line) {
+      position = idx + column
+      return true
+    }
+    return false
+  })
+
+  return position
 }

--- a/src/gleam_json_ffi.mjs
+++ b/src/gleam_json_ffi.mjs
@@ -1,6 +1,6 @@
-import { Ok, Error, toList } from './gleam.mjs'
+import { Ok, Error } from './gleam.mjs'
 import { bit_string_to_string } from '../../gleam_stdlib/dist/gleam_stdlib.mjs'
-import { UnexpectedByte, UnexpectedEndOfInput, UnexpectedFormat } from './gleam/json.mjs'
+import { UnexpectedByte, UnexpectedEndOfInput } from './gleam/json.mjs'
 
 export function json_to_string(json) {
   return JSON.stringify(json)

--- a/src/gleam_json_ffi.mjs
+++ b/src/gleam_json_ffi.mjs
@@ -22,18 +22,7 @@ export function do_null() {
   return null
 }
 
-export function decode(bit_string) {
-  const stringResult = bit_string_to_string(bit_string)
-  if (!stringResult.isOk()) return stringResult
-  try {
-    const result = JSON.parse(stringResult[0])
-    return new Ok(result)
-  } catch (err) {
-    return new Error(getJsonDecodeError(err))
-  }
-}
-
-export function decode_string_to_dynamic(string) {
+export function decode(string) {
   try {
     const result = JSON.parse(string)
     return new Ok(result)
@@ -45,7 +34,7 @@ export function decode_string_to_dynamic(string) {
 function getJsonDecodeError(stdErr) {
   if (isUnexpectedByte(stdErr)) return new toUnexpectedByteError(stdErr)
   if (isUnexpectedEndOfInput(stdErr)) return new UnexpectedEndOfInput()
-  return undefined
+  return new UnexpectedByte('', 0)
 }
 
 function isUnexpectedEndOfInput(err) {

--- a/src/gleam_json_ffi.mjs
+++ b/src/gleam_json_ffi.mjs
@@ -6,8 +6,12 @@ export function json_to_string(json) {
   return JSON.stringify(json)
 }
 
-export function object_from(entries) {
+export function object(entries) {
   return Object.fromEntries(entries)
+}
+
+export function identity(x) {
+  return x
 }
 
 export function array(list) {
@@ -18,28 +22,20 @@ export function do_null() {
   return null
 }
 
-export function string(x) {
-  return json_to_string(x)
-}
-
-export function int(x) {
-  return parseInt(json_to_string(x), 10)
-}
-
-export function float(x) {
-  return parseFloat(json_to_string(x), 10)
-}
-
-export function bool(x) {
-  return Boolean(x)
-}
-
-
 export function decode(bit_string) {
   const stringResult = bit_string_to_string(bit_string)
   if (!stringResult.isOk()) return stringResult
   try {
     const result = JSON.parse(stringResult[0])
+    return new Ok(result)
+  } catch (err) {
+    return new Error(getJsonDecodeError(err))
+  }
+}
+
+export function decode_string_to_dynamic(string) {
+  try {
+    const result = JSON.parse(string)
     return new Ok(result)
   } catch (err) {
     return new Error(getJsonDecodeError(err))

--- a/src/gleam_json_ffi.mjs
+++ b/src/gleam_json_ffi.mjs
@@ -1,65 +1,6 @@
-import { Ok, Error, CustomType } from './gleam.mjs'
+import { Ok, Error, toList } from './gleam.mjs'
 import { bit_string_to_string } from '../../gleam_stdlib/dist/gleam_stdlib.mjs'
-
-export class DecodeError extends CustomType {
-  get __gleam_prelude_variant__() {
-    return "DecodeError";
-  }
-}
-
-export class UnexpectedEndOfInput extends CustomType {
-  static isInstance(err) {
-    return err.message === 'Unexpected end of JSON input'
-  }
-
-  get __gleam_prelude_variant__() {
-    return "UnexpectedEndOfInput"
-  }
-}
-
-export class UnexpectedByte extends CustomType {
-  static regex = /Unexpected token (.) in JSON at position (\d+)/
-
-  static isInstance(err) {
-    return this.regex.test(err)
-  }
-
-  constructor(err) {
-    super()
-    const match = UnexpectedByte.regex.exec(err.message)
-    this.byte = "0x" + match[1].charCodeAt(0).toString(16).toUpperCase()
-    this.position = Number(match[2])
-  }
-
-  get __gleam_prelude_variant__() {
-    return `UnexpectedByte`;
-  }
-}
-
-export class UnexpectedSequence extends CustomType {
-  static isInstance(err) {
-    return false
-  }
-
-  get __gleam_prelude_variant__() {
-    return "UnexpectedSequence";
-  }
-}
-
-export class UnexpectedFormat extends CustomType {
-  static isInstance(err) {
-    return false
-  }
-
-  constructor(decodeErrs) {
-    super()
-    this[0] = decodeErrs
-  }
-
-  get __gleam_prelude_variant__() {
-    return "UnexpectedFormat";
-  }
-}
+import { UnexpectedByte, UnexpectedEndOfInput, UnexpectedFormat } from './gleam/json.mjs'
 
 export function json_to_string(json) {
   return JSON.stringify(json)
@@ -77,9 +18,22 @@ export function do_null() {
   return null
 }
 
-export function identity(x) {
-  return x
+export function string(x) {
+  return json_to_string(x)
 }
+
+export function int(x) {
+  return parseInt(json_to_string(x), 10)
+}
+
+export function float(x) {
+  return parseFloat(json_to_string(x), 10)
+}
+
+export function bool(x) {
+  return Boolean(x)
+}
+
 
 export function decode(bit_string) {
   const stringResult = bit_string_to_string(bit_string)
@@ -88,18 +42,29 @@ export function decode(bit_string) {
     const result = JSON.parse(stringResult[0])
     return new Ok(result)
   } catch (err) {
-    return getJsonDecodeError(err)
+    return new Error(getJsonDecodeError(err))
   }
 }
 
 function getJsonDecodeError(stdErr) {
-  const ErrClass = [
-    UnexpectedByte,
-    UnexpectedEndOfInput,
-    UnexpectedFormat,
-    UnexpectedSequence,
-  ].find((klass) => klass.isInstance(stdErr))
+  if (isUnexpectedByte(stdErr)) return new toUnexpectedByteError(stdErr)
+  if (isUnexpectedEndOfInput(stdErr)) return new UnexpectedEndOfInput()
+  return undefined
+}
 
-  if (ErrClass) return new Error(new ErrClass(stdErr))
-  else return new Error()
+function isUnexpectedEndOfInput(err) {
+  return err.message === 'Unexpected end of JSON input'
+}
+
+const unexpectedByteRegex = /Unexpected token (.) in JSON at position (\d+)/
+
+function isUnexpectedByte(err) {
+  return unexpectedByteRegex.test(err)
+}
+
+function toUnexpectedByteError(err) {
+  const match = unexpectedByteRegex.exec(err.message)
+  const byte = "0x" + match[1].charCodeAt(0).toString(16).toUpperCase()
+  const position = Number(match[2])
+  return new UnexpectedByte(byte, position)
 }

--- a/src/gleam_json_ffi.mjs
+++ b/src/gleam_json_ffi.mjs
@@ -66,9 +66,6 @@ function getJsonDecodeError(stdErr, json) {
  * 
  * JSON.parse('{"a"')
  * // => Unexpected end of JSON input
- * 
- * // in Chromium (correct)
- * 
  */
 const unexpectedEndOfInputRegex = /((unexpected (end|eof))|(end of data)|(unterminated string)|(json( parse error|\.parse)\: expected '(\:|\}|\])'))/i
 
@@ -108,6 +105,23 @@ function getUnexpectedByteRuntime(err) {
   return null
 }
 
+/**
+ * Converts a SyntaxError to an UnexpectedByte error based on the JS runtime.
+ * 
+ * For Chromium, the unexpected byte and position are reported by the runtime.
+ * 
+ * For JavascriptCore, only the unexpected byte is reported by the runtime, so
+ * there is no way to know which position that character is in unless we then
+ * parse the string again ourselves. So instead, the position is reported as 0.
+ * 
+ * For Spidermonkey, the position is reported by the runtime as a line and column number 
+ * and the unexpected byte is found using those coordinates.
+ * 
+ * @param {'chromium' | 'spidermonkey' | 'jscore'} runtime 
+ * @param {SyntaxError} err 
+ * @param {string} json 
+ * @returns {UnexpectedByte}
+ */
 function toUnexpectedByteError(runtime, err, json) {
   switch (runtime) {
     case Runtime.chromium:

--- a/src/gleam_json_ffi.mjs
+++ b/src/gleam_json_ffi.mjs
@@ -1,5 +1,4 @@
 import { Ok, Error } from './gleam.mjs'
-import { bit_string_to_string } from '../../gleam_stdlib/dist/gleam_stdlib.mjs'
 import { UnexpectedByte, UnexpectedEndOfInput } from './gleam/json.mjs'
 
 export function json_to_string(json) {
@@ -38,7 +37,7 @@ function getJsonDecodeError(stdErr) {
 }
 
 function isUnexpectedEndOfInput(err) {
-  return err.message === 'Unexpected end of JSON input'
+  return err.message.includes('Unexpected end') || err.message.includes('Unexpected EOF')
 }
 
 const unexpectedByteRegex = /Unexpected token (.) in JSON at position (\d+)/

--- a/test/gleam_json_js_ffi_test.gleam
+++ b/test/gleam_json_js_ffi_test.gleam
@@ -1,0 +1,72 @@
+import gleeunit
+import gleam/json.{DecodeError, UnexpectedByte, UnexpectedEndOfInput}
+import gleeunit/should
+
+if javascript {
+  pub fn main() {
+    gleeunit.main()
+  }
+}
+
+type StandardError {
+  StandardError(message: String)
+}
+
+// === End of input tests === //
+pub fn chromium_end_of_input_test() {
+  "Unexpected end of JSON input"
+  |> StandardError
+  |> get_json_decode_error("")
+  |> should.equal(UnexpectedEndOfInput)
+}
+
+pub fn spidermonkey_end_of_input_test() {
+  "JSON.parse: unexpected end of data at line 1 column 1 of the JSON data"
+  |> StandardError
+  |> get_json_decode_error("")
+  |> should.equal(UnexpectedEndOfInput)
+}
+
+pub fn javascript_core_end_of_input_test() {
+  "JSON Parse error: Unexpected EOF"
+  |> StandardError
+  |> get_json_decode_error("")
+  |> should.equal(UnexpectedEndOfInput)
+}
+
+// === Unexpected byte tests === //
+pub fn chromium_unexpected_byte_test() {
+  "Unexpected token a in JSON at position 5"
+  |> StandardError
+  |> get_json_decode_error("{\"b\":a}")
+  |> should.equal(UnexpectedByte(byte: "0x61", position: 5))
+}
+
+pub fn spidermonkey_unexpected_byte_test() {
+  "JSON.parse: expected property name or '}' at line 1 column 6 of the JSON data"
+  |> StandardError
+  |> get_json_decode_error("{\"b\":a}")
+  |> should.equal(UnexpectedByte(byte: "0x61", position: 5))
+}
+
+pub fn javascript_core_unexpected_byte_test() {
+  "JSON Parse error: Unexpected identifier \"a\""
+  |> StandardError
+  |> get_json_decode_error("{\"b\":a}")
+  |> should.equal(UnexpectedByte(byte: "0x61", position: 0))
+}
+
+pub fn spidermonkey_multiline_unexpected_byte_test() {
+  "JSON.parse: expected property name or '}' at line 2 column 6 of the JSON data"
+  |> StandardError
+  |> get_json_decode_error("{\n\"b\": a\n}")
+  |> should.equal(UnexpectedByte(byte: "0x61", position: 7))
+
+  "JSON.parse: expected double-quoted property name at line 3 column 1 of the JSON data"
+  |> StandardError
+  |> get_json_decode_error("{\n\"b\": \"x\",\na\n}")
+  |> should.equal(UnexpectedByte(byte: "0x61", position: 12))
+}
+
+external fn get_json_decode_error(StandardError, String) -> DecodeError =
+  "./gleam_json_ffi.mjs" "getJsonDecodeError"

--- a/test/gleam_json_js_ffi_test.gleam
+++ b/test/gleam_json_js_ffi_test.gleam
@@ -1,72 +1,67 @@
-import gleeunit
-import gleam/json.{DecodeError, UnexpectedByte, UnexpectedEndOfInput}
-import gleeunit/should
-
 if javascript {
-  pub fn main() {
-    gleeunit.main()
+  import gleam/json.{DecodeError, UnexpectedByte, UnexpectedEndOfInput}
+  import gleeunit/should
+
+  type StandardError {
+    StandardError(message: String)
   }
+
+  // === End of input tests === //
+  pub fn chromium_end_of_input_test() {
+    "Unexpected end of JSON input"
+    |> StandardError
+    |> get_json_decode_error("")
+    |> should.equal(UnexpectedEndOfInput)
+  }
+
+  pub fn spidermonkey_end_of_input_test() {
+    "JSON.parse: unexpected end of data at line 1 column 1 of the JSON data"
+    |> StandardError
+    |> get_json_decode_error("")
+    |> should.equal(UnexpectedEndOfInput)
+  }
+
+  pub fn javascript_core_end_of_input_test() {
+    "JSON Parse error: Unexpected EOF"
+    |> StandardError
+    |> get_json_decode_error("")
+    |> should.equal(UnexpectedEndOfInput)
+  }
+
+  // === Unexpected byte tests === //
+  pub fn chromium_unexpected_byte_test() {
+    "Unexpected token a in JSON at position 5"
+    |> StandardError
+    |> get_json_decode_error("{\"b\":a}")
+    |> should.equal(UnexpectedByte(byte: "0x61", position: 5))
+  }
+
+  pub fn spidermonkey_unexpected_byte_test() {
+    "JSON.parse: expected property name or '}' at line 1 column 6 of the JSON data"
+    |> StandardError
+    |> get_json_decode_error("{\"b\":a}")
+    |> should.equal(UnexpectedByte(byte: "0x61", position: 5))
+  }
+
+  pub fn javascript_core_unexpected_byte_test() {
+    "JSON Parse error: Unexpected identifier \"a\""
+    |> StandardError
+    |> get_json_decode_error("{\"b\":a}")
+    |> should.equal(UnexpectedByte(byte: "0x61", position: 0))
+  }
+
+  pub fn spidermonkey_multiline_unexpected_byte_test() {
+    "JSON.parse: expected property name or '}' at line 2 column 6 of the JSON data"
+    |> StandardError
+    |> get_json_decode_error("{\n\"b\": a\n}")
+    |> should.equal(UnexpectedByte(byte: "0x61", position: 7))
+
+    "JSON.parse: expected double-quoted property name at line 3 column 1 of the JSON data"
+    |> StandardError
+    |> get_json_decode_error("{\n\"b\": \"x\",\na\n}")
+    |> should.equal(UnexpectedByte(byte: "0x61", position: 12))
+  }
+
+  external fn get_json_decode_error(StandardError, String) -> DecodeError =
+    "./gleam_json_ffi.mjs" "getJsonDecodeError"
 }
-
-type StandardError {
-  StandardError(message: String)
-}
-
-// === End of input tests === //
-pub fn chromium_end_of_input_test() {
-  "Unexpected end of JSON input"
-  |> StandardError
-  |> get_json_decode_error("")
-  |> should.equal(UnexpectedEndOfInput)
-}
-
-pub fn spidermonkey_end_of_input_test() {
-  "JSON.parse: unexpected end of data at line 1 column 1 of the JSON data"
-  |> StandardError
-  |> get_json_decode_error("")
-  |> should.equal(UnexpectedEndOfInput)
-}
-
-pub fn javascript_core_end_of_input_test() {
-  "JSON Parse error: Unexpected EOF"
-  |> StandardError
-  |> get_json_decode_error("")
-  |> should.equal(UnexpectedEndOfInput)
-}
-
-// === Unexpected byte tests === //
-pub fn chromium_unexpected_byte_test() {
-  "Unexpected token a in JSON at position 5"
-  |> StandardError
-  |> get_json_decode_error("{\"b\":a}")
-  |> should.equal(UnexpectedByte(byte: "0x61", position: 5))
-}
-
-pub fn spidermonkey_unexpected_byte_test() {
-  "JSON.parse: expected property name or '}' at line 1 column 6 of the JSON data"
-  |> StandardError
-  |> get_json_decode_error("{\"b\":a}")
-  |> should.equal(UnexpectedByte(byte: "0x61", position: 5))
-}
-
-pub fn javascript_core_unexpected_byte_test() {
-  "JSON Parse error: Unexpected identifier \"a\""
-  |> StandardError
-  |> get_json_decode_error("{\"b\":a}")
-  |> should.equal(UnexpectedByte(byte: "0x61", position: 0))
-}
-
-pub fn spidermonkey_multiline_unexpected_byte_test() {
-  "JSON.parse: expected property name or '}' at line 2 column 6 of the JSON data"
-  |> StandardError
-  |> get_json_decode_error("{\n\"b\": a\n}")
-  |> should.equal(UnexpectedByte(byte: "0x61", position: 7))
-
-  "JSON.parse: expected double-quoted property name at line 3 column 1 of the JSON data"
-  |> StandardError
-  |> get_json_decode_error("{\n\"b\": \"x\",\na\n}")
-  |> should.equal(UnexpectedByte(byte: "0x61", position: 12))
-}
-
-external fn get_json_decode_error(StandardError, String) -> DecodeError =
-  "./gleam_json_ffi.mjs" "getJsonDecodeError"

--- a/test/gleam_json_test.gleam
+++ b/test/gleam_json_test.gleam
@@ -2,7 +2,6 @@ import gleam/dynamic
 import gleam/json.{Json}
 import gleam/option.{None, Some}
 import gleam/string_builder
-import gleam/result
 import gleeunit
 import gleeunit/should
 

--- a/test/gleam_json_test.gleam
+++ b/test/gleam_json_test.gleam
@@ -27,9 +27,7 @@ pub fn decode_unexpected_byte_test() {
 
 pub fn decode_unexpected_format_test() {
   json.decode(from: "[]", using: dynamic.int)
-  |> should.equal(Error(json.UnexpectedFormat([
-    dynamic.DecodeError(expected: "Int", found: "List", path: []),
-  ])))
+  |> should.equal(Error(json.UnexpectedFormat([empty_list_decode_error()])))
 }
 
 pub fn decode_bits_test() {
@@ -49,9 +47,7 @@ pub fn decode_bits_unexpected_byte_test() {
 
 pub fn decode_bits_unexpected_format_test() {
   json.decode_bits(from: <<"[]":utf8>>, using: dynamic.int)
-  |> should.equal(Error(json.UnexpectedFormat([
-    dynamic.DecodeError(expected: "Int", found: "List", path: []),
-  ])))
+  |> should.equal(Error(json.UnexpectedFormat([empty_list_decode_error()])))
 }
 
 pub fn encode_string_test() {
@@ -125,4 +121,16 @@ fn should_encode(data: Json, expected: String) {
   |> json.to_string_builder
   |> string_builder.to_string
   |> should.equal(json.to_string(data))
+}
+
+if erlang {
+  fn empty_list_decode_error() -> dynamic.DecodeError {
+    dynamic.DecodeError(expected: "Int", found: "List", path: [])
+  }
+}
+
+if javascript {
+  fn empty_list_decode_error() {
+    dynamic.DecodeError(expected: "Int", found: "Tuple of 0 elements", path: [])
+  }
 }


### PR DESCRIPTION
Adds support for javascript as the build target.

**Changes:**
- Upgrades `gleeunit` to `~> 0.6` (there is a bug in the javascript output of the current version that throws errors when running tests with the target set to javascript).
- Adds javascript ffi