### PR TITLE
Greenkeeping

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -13,7 +13,7 @@ links = [
 
 [dependencies]
 gleam_stdlib = "~> 0.19 or ~> 1.0"
-thoas = "~> 0.2"
+thoas = "~> 1.2"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "gleam_json"
-version = "1.0.0"
+version = "1.0.1"
 gleam = ">= 0.32.0"
 
 licences = ["Apache-2.0"]
@@ -12,7 +12,7 @@ links = [
 ]
 
 [dependencies]
-gleam_stdlib = "~> 0.19 or ~> 1.0"
+gleam_stdlib = "~> 0.32 or ~> 1.0"
 thoas = "~> 1.2"
 
 [dev-dependencies]

--- a/manifest.toml
+++ b/manifest.toml
@@ -4,10 +4,10 @@
 packages = [
   { name = "gleam_stdlib", version = "0.34.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "1FB8454D2991E9B4C0C804544D8A9AD0F6184725E20D63C3155F0AEB4230B016" },
   { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
-  { name = "thoas", version = "0.4.1", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "4918D50026C073C4AB1388437132C77A6F6F7C8AC43C60C13758CC0ADCE2134E" },
+  { name = "thoas", version = "1.2.0", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "540C8CB7D9257F2AD0A14145DC23560F91ACDCA995F0CCBA779EB33AF5D859D1" },
 ]
 
 [requirements]
 gleam_stdlib = { version = "~> 0.19 or ~> 1.0" }
 gleeunit = { version = "~> 1.0" }
-thoas = { version = "~> 0.2" }
+thoas = { version = "~> 1.2" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -8,6 +8,6 @@ packages = [
 ]
 
 [requirements]
-gleam_stdlib = { version = "~> 0.19 or ~> 1.0" }
+gleam_stdlib = { version = "~> 0.32 or ~> 1.0" }
 gleeunit = { version = "~> 1.0" }
 thoas = { version = "~> 1.2" }


### PR DESCRIPTION
Upgrading Thoas to version 1.2 and raising the minimum required version of the Gleam standard library to match Gleam's release version 0.32