### PR TITLE
Remove deprecated dynamic decoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- The `decode` and `decode_bits` functions, and the `UnexpectedFormat` variant,
+  relying on the deprecated `gleam/dynamic` API have been removed from the
+  `json` module.
+
 ## v2.3.0 - 2025-01-04
 
 - Add `dict` function

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,8 +2,8 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.51.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "14AFA8D3DDD7045203D422715DBB822D1725992A31DF35A08D97389014B74B68" },
-  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
+  { name = "gleam_stdlib", version = "0.60.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "621D600BB134BC239CB2537630899817B1A42E60A1D46C5E9F3FAE39F88C800B" },
+  { name = "gleeunit", version = "1.3.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "A7DD6C07B7DA49A6E28796058AA89E651D233B357D5607006D70619CD89DAAAB" },
 ]
 
 [requirements]

--- a/src/gleam/json.gleam
+++ b/src/gleam/json.gleam
@@ -13,17 +13,7 @@ pub type DecodeError {
   UnexpectedEndOfInput
   UnexpectedByte(String)
   UnexpectedSequence(String)
-  UnexpectedFormat(List(dynamic.DecodeError))
   UnableToDecode(List(decode.DecodeError))
-}
-
-/// The same as `parse`, but using the old `gleam/dynamic` decoder API.
-///
-pub fn decode(
-  from json: String,
-  using decoder: dynamic.Decoder(t),
-) -> Result(t, DecodeError) {
-  do_decode(from: json, using: decoder)
 }
 
 /// Decode a JSON string into dynamically typed data which can be decoded into
@@ -72,38 +62,8 @@ fn do_parse(
   |> result.map_error(UnableToDecode)
 }
 
-@target(erlang)
-fn do_decode(
-  from json: String,
-  using decoder: dynamic.Decoder(t),
-) -> Result(t, DecodeError) {
-  let bits = bit_array.from_string(json)
-  decode_bits(bits, decoder)
-}
-
-@target(javascript)
-fn do_decode(
-  from json: String,
-  using decoder: dynamic.Decoder(t),
-) -> Result(t, DecodeError) {
-  use dynamic_value <- result.then(decode_string(json))
-  decoder(dynamic_value)
-  |> result.map_error(UnexpectedFormat)
-}
-
 @external(javascript, "../gleam_json_ffi.mjs", "decode")
 fn decode_string(a: String) -> Result(Dynamic, DecodeError)
-
-/// The same as `parse_bits`, but using the old `gleam/dynamic` decoder API.
-///
-pub fn decode_bits(
-  from json: BitArray,
-  using decoder: dynamic.Decoder(t),
-) -> Result(t, DecodeError) {
-  use dynamic_value <- result.then(decode_to_dynamic(json))
-  decoder(dynamic_value)
-  |> result.map_error(UnexpectedFormat)
-}
 
 /// Decode a JSON bit string into dynamically typed data which can be decoded
 /// into typed data with the `gleam/dynamic` module.

--- a/test/gleam_json_test.gleam
+++ b/test/gleam_json_test.gleam
@@ -1,5 +1,4 @@
 import gleam/dict
-import gleam/dynamic
 import gleam/dynamic/decode
 import gleam/int
 import gleam/json.{type Json}
@@ -17,35 +16,30 @@ pub fn main() {
 const list_found = "List"
 
 @target(javascript)
-const list_found = "Tuple of 0 elements"
-
-pub fn decode_test() {
-  json.decode(from: "5", using: dynamic.int)
-  |> should.equal(Ok(5))
-}
+const list_found = "Array"
 
 pub fn parse_test() {
   json.parse(from: "5", using: decode.int)
   |> should.equal(Ok(5))
 }
 
-pub fn decode_empty_test() {
-  json.decode(from: "", using: dynamic.int)
+pub fn parse_empty_test() {
+  json.parse(from: "", using: decode.int)
   |> should.equal(Error(json.UnexpectedEndOfInput))
 }
 
-pub fn decode_unexpected_byte_test() {
-  let assert Error(error) = json.decode(from: "[}", using: dynamic.int)
+pub fn parse_unexpected_byte_test() {
+  let assert Error(error) = json.parse(from: "[}", using: decode.int)
   let assert json.UnexpectedByte(byte) = error
   let assert "0x7D" = byte
 }
 
-pub fn decode_unexpected_format_test() {
-  json.decode(from: "[]", using: dynamic.int)
+pub fn parse_unexpected_format_test() {
+  json.parse(from: "[]", using: decode.int)
   |> should.equal(
     Error(
-      json.UnexpectedFormat([
-        dynamic.DecodeError(expected: "Int", found: list_found, path: []),
+      json.UnableToDecode([
+        decode.DecodeError(expected: "Int", found: list_found, path: []),
       ]),
     ),
   )
@@ -62,41 +56,35 @@ pub fn parse_unable_to_decode_test() {
   )
 }
 
-pub fn decode_bits_test() {
-  json.decode_bits(from: <<"5":utf8>>, using: dynamic.int)
-  |> should.equal(Ok(5))
-}
-
 pub fn parse_bits_test() {
   json.parse_bits(from: <<"5":utf8>>, using: decode.int)
   |> should.equal(Ok(5))
 }
 
-pub fn decode_bits_empty_test() {
-  json.decode_bits(from: <<"":utf8>>, using: dynamic.int)
+pub fn parse_bits_empty_test() {
+  json.parse_bits(from: <<"":utf8>>, using: decode.int)
   |> should.equal(Error(json.UnexpectedEndOfInput))
 }
 
-pub fn decode_bits_unexpected_byte_test() {
-  let assert Error(error) = json.decode(from: "[}", using: dynamic.int)
+pub fn parse_bits_unexpected_byte_test() {
+  let assert Error(error) = json.parse(from: "[}", using: decode.int)
   let assert json.UnexpectedByte(byte) = error
   let assert "0x7D" = byte
 }
 
-pub fn decode_bits_unexpected_format_test() {
-  json.decode_bits(from: <<"[]":utf8>>, using: dynamic.int)
+pub fn parse_bits_unexpected_format_test() {
+  json.parse_bits(from: <<"[]":utf8>>, using: decode.int)
   |> should.equal(
     Error(
-      json.UnexpectedFormat([
-        dynamic.DecodeError(expected: "Int", found: list_found, path: []),
+      json.UnableToDecode([
+        decode.DecodeError(expected: "Int", found: list_found, path: []),
       ]),
     ),
   )
 }
 
-pub fn decode_unexpected_sequence_test() {
-  let assert Error(error) =
-    json.decode(from: "\"\\uxxxx\"", using: dynamic.float)
+pub fn parse_unexpected_sequence_test() {
+  let assert Error(error) = json.parse(from: "\"\\uxxxx\"", using: decode.float)
   case error {
     json.UnexpectedSequence("\\uxxxx") -> Nil
     json.UnexpectedByte("0x78") -> Nil


### PR DESCRIPTION
Hello! With this PR I'm removing the json functions relying on the deprecated dynamic API which has now been removed from the standard library. Since this would be a breaking change we might as well remove the other deprecated `to_string_builder` function before making a new major release!