### PR TITLE
create objects without null properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add `sparse` function to omit null properties from created objects.
+
 ## v3.0.2 - 2025-07-01
 
 - Updated for lastest `gleam_stdlib`.

--- a/src/gleam/json.gleam
+++ b/src/gleam/json.gleam
@@ -254,7 +254,7 @@ pub fn nullable(from input: Option(a), of inner_type: fn(a) -> Json) -> Json {
 ///   #("game", string("Pac-Man")),
 ///   #("score", int(3333360)),
 /// ]))
-/// "{\"game\":\"Pac-Mac\",\"score\":3333360}"
+/// "{\"game\":\"Pac-Man\",\"score\":3333360}"
 /// ```
 ///
 pub fn object(entries: List(#(String, Json))) -> Json {
@@ -264,6 +264,27 @@ pub fn object(entries: List(#(String, Json))) -> Json {
 @external(erlang, "gleam_json_ffi", "object")
 @external(javascript, "../gleam_json_ffi.mjs", "object")
 fn do_object(entries entries: List(#(String, Json))) -> Json
+
+/// Encode a list of key-value pairs into a JSON object.
+/// Omit any properties that are null.
+///
+/// ## Examples
+///
+/// ```gleam
+/// > to_string(object([
+///   #("game", string("Sonic")),
+///   #("score", null()),
+/// ]))
+/// "{\"game\":\"Sonic\"}"
+/// ```
+///
+pub fn sparse(entries: List(#(String, Json))) -> Json {
+  list.filter(entries, fn(entry) {
+    let #(_, v) = entry
+    v != null()
+  })
+  |> object
+}
 
 /// Encode a list into a JSON array.
 ///

--- a/test/gleam_json_test.gleam
+++ b/test/gleam_json_test.gleam
@@ -128,6 +128,16 @@ pub fn encode_empty_object_test() {
   |> should_encode("{}")
 }
 
+pub fn encode_sparse_object_test() {
+  json.sparse([#("foo", json.int(5))])
+  |> should_encode("{\"foo\":5}")
+}
+
+pub fn encode_empty_sparse_object_test() {
+  json.sparse([])
+  |> should_encode("{}")
+}
+
 pub fn encode_empty_array_test() {
   []
   |> json.array(of: json.int)


### PR DESCRIPTION
I keep rewriting this function, normally after finding a bug in my system.

The recent version of this problem was creating workflows on cloudflare https://developers.cloudflare.com/workflows/build/workers-api/#create
Passing a  createOptions without the id field and cloudflare will generate a unique id on every call. pass in a createOptions with id: null and the id given is null and on the first call will actually trigger a workflow.

I know you can do this outside the library but I keep coming into issues like the above so maybe it's helpful