### PR TITLE
Fix decode example not importing Cat type

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ JSON is parsed into a `Dynamic` value which can be decoded using the
 `gleam/dynamic/decode` module from the Gleam standard library.
 
 ```gleam
-import myapp.{Cat}
+import myapp.{type Cat, Cat}
 import gleam/json
 import gleam/dynamic/decode
 


### PR DESCRIPTION
without import `type Cat` the decode example doesn't pass `gleam check`